### PR TITLE
Update version regex for nvim v0.1.7

### DIFF
--- a/autoload/nvimapi.vim
+++ b/autoload/nvimapi.vim
@@ -5,7 +5,7 @@ function! s:version() abort
     return ''
   endif
 
-  return matchstr(execute('silent version'), 'NVIM v\zs[0-9.]\+')
+  return matchstr(execute('silent version'), 'NVIM v\?\zs[0-9.]\+')
 endfunction
 
 function! s:show_buffer() abort


### PR DESCRIPTION
Neovim doesn't prefix the version number with a `v`, AFAICT.  Couldn't really determine when nvim included `v` in the version numbers.